### PR TITLE
Instance termination, fix  #48

### DIFF
--- a/dva/work/stage.py
+++ b/dva/work/stage.py
@@ -6,7 +6,6 @@ import logging
 import time
 import os
 import traceback
-#import terminate
 
 from functools import wraps
 from stitches import Expect, ExpectFailed
@@ -111,7 +110,6 @@ def create_instance(params):
         logger.debug('Skip Cloud Exception: %s', err)
         raise SkipError(err)
     params['id_region'] = str(params['id']) +'_' + str(params['region'])
-    # params[terminate.TOKEN] = terminate.token_value(params['id'], params['region'])
     return params
 
 

--- a/dva/work/stage.py
+++ b/dva/work/stage.py
@@ -6,6 +6,8 @@ import logging
 import time
 import os
 import traceback
+#import terminate
+
 from functools import wraps
 from stitches import Expect, ExpectFailed
 from stitches.connection import StitchesConnectionException
@@ -108,6 +110,8 @@ def create_instance(params):
         # this instance type can't be created in this region
         logger.debug('Skip Cloud Exception: %s', err)
         raise SkipError(err)
+    params['id_region'] = str(params['id']) +'_' + str(params['region'])
+    # params[terminate.TOKEN] = terminate.token_value(params['id'], params['region'])
     return params
 
 

--- a/dva/work/terminate.py
+++ b/dva/work/terminate.py
@@ -5,8 +5,6 @@ import re
 from data import record_cloud_config
 from stage import terminate_instance
 
-#TOKEN='id_region'
-
 ID_PARAMS = {
     'cloud': None,
     'enabled': True,
@@ -17,13 +15,6 @@ ID_PARAMS = {
     'itype':None,
     'ami':None
 }
-
-#def token_value(instance_id, region):
-#    return str(instance_id) + '_' + str(region)
-
-#def parse_token(token_value):
-#    return token_value.split('_')
-
 
 def main(conf, istream, ostream, cloud, verbose):
 
@@ -54,4 +45,3 @@ def main(conf, istream, ostream, cloud, verbose):
             print p['id'], p['region'], "was terminated"
         except Exception as e:
             print "Exception {0}".format(e)
-

--- a/dva/work/terminate.py
+++ b/dva/work/terminate.py
@@ -2,44 +2,56 @@
 terminate all created instances
 '''
 import re
-from itertools import product
-from stage import terminate_instance
 from data import record_cloud_config
+from stage import terminate_instance
+
+#TOKEN='id_region'
+
+ID_PARAMS = {
+    'cloud': None,
+    'enabled': True,
+    'hostname': None,
+    'cloudhwname': None,
+    'platform':None,
+    'version':None,
+    'itype':None,
+    'ami':None
+}
+
+#def token_value(instance_id, region):
+#    return str(instance_id) + '_' + str(region)
+
+#def parse_token(token_value):
+#    return token_value.split('_')
+
 
 def main(conf, istream, ostream, cloud, verbose):
 
-    amis = []
-    regions = []
+    id_region_list = []
     file_data = istream.readlines()
     for line in file_data:
-        ami_id = re.search("i-[a-z0-9]{8}", line)
-        region = re.search("region: [a-z0-9-]*", line)
-        if ami_id:
-            amis.append(ami_id.group(0))
-        if region:
-            regions.append(re.sub("region:\s*", "", region.group(0)))
-    amis = list(set(amis))
-    regions =  list(set(regions))
+        # If there is a chance that broken validation data.yaml file may contain more than
+        # one occurrence of 'id_region' string in a line, 're.search' should be replaced with
+        # 're.findall'. All further code should be updated as 're.findall'
+        # returns a list, not a _sre.SRE_Match object.
 
-    params = {}
-    params['cloud'] = cloud
-    params['enabled'] = True
-    params['hostname'] = None
-    params['cloudhwname']=None
-    params['platform']=None
-    params['version']=None
-    params['itype']=None
-    params['ami']=None
+        id_region = re.search("id_region:\ [a-z0-9-_]*", line)
+        if id_region:
+            id_region_list.append(id_region.group(0))
 
-    print "There will be {0} termination calls".format(len(amis)*len(regions))
-    for x in product(regions, amis):
-        params['region'] = x[0]
-        params['id'] = x[1]
-        params['enabled'] = True
-        record_cloud_config(params, conf)
-	try:
-            term_result = terminate_instance(params)
-            print term_result >> ostmeam
-            print params['id'], params['region'], "was terminated"
-        except:
-            pass
+    id_region_set = set(id_region_list)
+    unique_id_region_list=list(id_region_set)
+    for id_region in unique_id_region_list:
+        instance_id_region = id_region[11:].split('_')
+	p = ID_PARAMS.copy()
+        p['id'] = instance_id_region[0]
+        p['region'] = instance_id_region[1]
+        p['cloud'] = cloud
+        record_cloud_config(p, conf)
+        print p['id'] + " in a region " + p['region'] + " will be terminated."
+        try:
+            terminate_instance(p)
+            print p['id'], p['region'], "was terminated"
+        except Exception as e:
+            print "Exception {0}".format(e)
+


### PR DESCRIPTION
Termination of all instances works for me on all regions. It's needed to be checked on gov and china regions. Some code optimisation and logging are needed to be fixed. 

To use: 
`dva -c ~/.ssh/dva.yaml terminate -i /tmp/result_validation.yaml -o /tmp/result_termination.yaml`

where /tmp/result_validation.yaml is a broken yaml file created by dva validation command