### PR TITLE
Security groups definition

### DIFF
--- a/dva/cloud/ec2.py
+++ b/dva/cloud/ec2.py
@@ -87,7 +87,8 @@ class EC2(AbstractCloud):
                 key_name=ssh_key_name,
                 block_device_map=bmap,
                 subnet_id=params.get('subnet_id'),
-                user_data=params.get('userdata')
+                user_data=params.get('userdata'),
+                security_groups=params.get('security_groups'),
             )
             myinstance = reservation.instances[0]
             count = 0

--- a/dva/work/data.py
+++ b/dva/work/data.py
@@ -26,7 +26,8 @@ DEFAULT_FIELDS = {
     'bmap': {},
     'userdata': '',
     'keepalive': False,
-    'region_endpoint': None
+    'region_endpoint': None,
+    'security_groups': ['default']
 }
 
 EPHEMERAL_FIELDS = ['credentials', 'global_setup_script', 'instance', 'ssh', 'test_stages', 'user_data',


### PR DESCRIPTION
It's possible to define different security groups in data.yaml. If none is given, dva uses the one called 'default', which is the default one for all regions.