### PR TITLE
RPyC lib dependency

### DIFF
--- a/dva/test/testcase_26_verify_rpms.py
+++ b/dva/test/testcase_26_verify_rpms.py
@@ -17,8 +17,9 @@ class testcase_26_verify_rpms(Testcase):
         plat = params['platform'].upper()
         prod = params['product'].upper()
         ver = params['version']
-        
+
         if connection.rpyc is None:
+            # in case RPyC library is missing, we try to satisfy the dependancy with an rpm recommended by stitches
             self.get_result(connection, 'curl https://rhuiqerpm.s3.amazonaws.com/python-rpyc-3.2.3-1.fc21.noarch.rpm -o /tmp/rpyc.rpm && rpm -i /tmp/rpyc.rpm', 60)
             if connection.rpyc is None:
                 self.log.append({

--- a/dva/test/testcase_26_verify_rpms.py
+++ b/dva/test/testcase_26_verify_rpms.py
@@ -17,12 +17,14 @@ class testcase_26_verify_rpms(Testcase):
         plat = params['platform'].upper()
         prod = params['product'].upper()
         ver = params['version']
-
+        
         if connection.rpyc is None:
-            self.log.append({
-                'result': RESULT_FAILED,
-                'comment': 'test can\'t be performed without RPyC connection'})
-            return self.log
+            self.get_result(connection, 'curl https://rhuiqerpm.s3.amazonaws.com/python-rpyc-3.2.3-1.fc21.noarch.rpm -o /tmp/rpyc.rpm && rpm -i /tmp/rpyc.rpm', 60)
+            if connection.rpyc is None:
+                self.log.append({
+                                 'result': RESULT_FAILED,
+                                 'comment': 'test can\'t be performed without RPyC connection'})
+                return self.log
 
         modified_files = {}
 

--- a/dva/test/testcase_27_yum_repos.py
+++ b/dva/test/testcase_27_yum_repos.py
@@ -21,10 +21,13 @@ class testcase_27_yum_repos(Testcase):
         prod = params['product'].upper()
         ver = params['version']
         if connection.rpyc is None:
-            self.log.append({
-                'result': RESULT_FAILED,
-                'comment': 'test can\'t be performed without RPyC connection'})
-            return self.log
+            # in case RPyC library is missing, we try to satisfy the dependancy with an rpm recommended by stitches
+            self.get_result(connection, 'curl https://rhuiqerpm.s3.amazonaws.com/python-rpyc-3.2.3-1.fc21.noarch.rpm -o /tmp/rpyc.rpm && rpm -i /tmp/rpyc.rpm', 60)
+            if connection.rpyc is None:
+                self.log.append({
+                    'result': RESULT_FAILED,
+                    'comment': 'test can\'t be performed without RPyC connection'})
+                return self.log
         repos = {}
         rbase = connection.rpyc.modules.yum.YumBase()
         for repo in rbase.repos.repos:


### PR DESCRIPTION
A fix to satisfy RPyC library dependency, which is required by python-stitches. 