### PR TITLE
Updated date command for testcase 67

### DIFF
--- a/dva/test/testcase_67_timezone.py
+++ b/dva/test/testcase_67_timezone.py
@@ -12,6 +12,6 @@ class testcase_67_timezone(Testcase):
 
     # pylint: disable=unused-argument
     def test(self, connection, params):
-        self.get_return_value(connection, 'date | grep UTC')
+        self.get_return_value(connection, 'date -u | grep UTC')
         return self.log
 


### PR DESCRIPTION
This was updated for date command to reflect UTC time to prevent test case 67 from failing.