### PR TITLE
Pin gevent to 1.1.2 as gevent.coros no longer available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='dva',
     license="GPLv3+",
     provides='dva',
     install_requires=['PyYAML', 'aaargh', 'stitches>=0.9', 'boto>=2.36.0',
-        'gevent', 'html', 'python-bugzilla', 'requests', 'urllib3'],
+        'gevent<=1.1.2', 'html', 'python-bugzilla', 'requests', 'urllib3'],
     packages=[
         'dva', 'dva.test', 'dva.cloud', 'dva.work', 'dva.tools', 'dva.connection', 'dva.report'
         ],


### PR DESCRIPTION
gevent.coros renamed to gevent.lock in gevent 1.2.
This could serve as temporary solution until thought otherwise.