### PR TITLE
testcase_80_no_avc_denials: check dmesg output instead of /var/log/dmesg in atomic image

### DIFF
--- a/dva/test/testcase_80_no_avc_denials.py
+++ b/dva/test/testcase_80_no_avc_denials.py
@@ -16,8 +16,10 @@ class testcase_80_no_avc_denials(Testcase):
         prod = params['product'].upper()
 
         if prod == 'ATOMIC':
-            self.ping_pong(connection, 'echo START; grep \'avc:[[:space:]]*denied\' /var/log/dmesg | grep -v userdata; echo END', '\r\nSTART\r\nEND\r\n', 60)
+            self.ping_pong(
+                connection, 'echo START; dmesg | grep \'avc:[[:space:]]*denied\' | grep -v userdata; echo END', '\r\nSTART\r\nEND\r\n', 60)
         else:
-            self.ping_pong(connection, 'echo START; grep \'avc:[[:space:]]*denied\' /var/log/messages /var/log/audit/audit.log | grep -v userdata; echo END', '\r\nSTART\r\nEND\r\n', 60)
+            self.ping_pong(
+                connection, 'echo START; grep \'avc:[[:space:]]*denied\' /var/log/messages /var/log/audit/audit.log | grep -v userdata; echo END', '\r\nSTART\r\nEND\r\n', 60)
 
         return self.log


### PR DESCRIPTION

Following the decision of RHBZ#1565291, check dmesg output directly.

Signed-off-by: Xiao Liang <xiliang@redhat.com>