### PR TITLE
fix missed change in commit "gevent.coros has been renamed to gevent.lock"

### DIFF
--- a/dva/report/bug_main.py
+++ b/dva/report/bug_main.py
@@ -12,7 +12,7 @@ from ..work.data import load_yaml, save_result, set_config_filename
 from ..work.common import RESULT_PASSED, RESULT_SKIP, RESULT_WAIVED, RESULT_FAILED, RESULT_ERROR
 from result import get_hwp_result
 from gevent.pool import Pool
-from gevent.coros import RLock
+from gevent.lock import RLock
 import yaml
 try:
     from yaml import CDumper as Dumper


### PR DESCRIPTION

Signed-off-by: Xiao Liang <xiliang@redhat.com>